### PR TITLE
Disponibilités : Validation des conflits

### DIFF
--- a/src/Controller/DisponibiliteController.php
+++ b/src/Controller/DisponibiliteController.php
@@ -38,6 +38,8 @@ class DisponibiliteController extends AbstractController
     public function mesDispoAjouter(Request $request, DisponibiliteRepository $dispoRepository): Response
     {
         $nouvelleDispo = new Disponibilite();
+        $nouvelleDispo->setFamille($this->getUser());
+
         $form = $this->createForm(DisponibiliteType::class, $nouvelleDispo);
 
         $form->handleRequest($request);
@@ -46,7 +48,6 @@ class DisponibiliteController extends AbstractController
         {
 
             $nouvelleDispo = $form->getData();
-            $nouvelleDispo->setFamille($this->getUser());
 
             $dispoRepository->add($nouvelleDispo, true);
 

--- a/src/Controller/DisponibiliteController.php
+++ b/src/Controller/DisponibiliteController.php
@@ -113,6 +113,8 @@ class DisponibiliteController extends AbstractController
     public function ajouterAFamille(Famille $famille, Request $request, DisponibiliteRepository $dispoRepository): Response
     {
         $nouvelleDispo = new Disponibilite();
+        $nouvelleDispo->setFamille($famille);
+
         $form = $this->createForm(DisponibiliteType::class, $nouvelleDispo);
 
         $form->handleRequest($request);
@@ -121,7 +123,6 @@ class DisponibiliteController extends AbstractController
         {
 
             $nouvelleDispo = $form->getData();
-            $nouvelleDispo->setFamille($famille);
 
             $dispoRepository->add($nouvelleDispo, true);
 

--- a/src/Form/DisponibiliteType.php
+++ b/src/Form/DisponibiliteType.php
@@ -16,6 +16,8 @@ class DisponibiliteType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $today = new DateTimeImmutable('now');
+        $dateDebut = new DateTimeImmutable('tomorrow 10am');
+        $dateFin = new DateTimeImmutable('+2 days 6pm');
         $anneeMin = $today->format('Y');
         $anneeMax = $today->add(new DateInterval('P1Y'))->format('Y');
 
@@ -25,14 +27,14 @@ class DisponibiliteType extends AbstractType
                 'label' => 'Début de la disponibilité',
                 'with_seconds' => false,
                 'years' => range($anneeMin, $anneeMax),
-                'data' => $today,
+                'data' => $dateDebut,
             ])
             ->add('fin', DateTimeType::class, [
                 'input' => 'datetime_immutable',
                 'label' => 'Fin de la disponibilité',
                 'with_seconds' => false,
                 'years' => range($anneeMin, $anneeMax),
-                'data' => $today->add(new DateInterval('P1D')),
+                'data' => $dateFin,
             ])
             ->add('libelle')
             ->add('ajouter', SubmitType::class)

--- a/src/Validator/Disponibilite.php
+++ b/src/Validator/Disponibilite.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"CLASS", "ANNOTATION"})
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class Disponibilite extends Constraint
+{
+    /*
+     * Any public properties become valid options for the annotation.
+     * Then, use these in your validator class.
+     */
+    public $message = 'Cette disponibilité entre en conflit avec la suivante : {{ value }}';
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Validator/DisponibiliteValidator.php
+++ b/src/Validator/DisponibiliteValidator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class DisponibiliteValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        /* @var App\Validator\Disponibilite $constraint */
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (get_class($value) !== \App\Entity\Disponibilite::class)
+        {
+            throw new UnexpectedTypeException($value, \App\Entity\Disponibilite::class);
+        }
+
+
+        $disponibilites = $value->getFamille()->getDisponibilites();
+
+        foreach ($disponibilites as $disponibilite) {
+            if (
+                ($disponibilite->getFin() > $value->getDebut()) && ($disponibilite->getDebut() < $value->getFin())
+            )
+            {
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $disponibilite)
+                    ->addViolation();
+            }
+        }
+
+
+    }
+}


### PR DESCRIPTION
Une famille ne peut maintenant plus créer une disponibilitée si elle se superpose avec une autre.

Si une telle action est tentée, un message apparaîtra sur le formulaire pour chaque disponibilité avec laquelle la nouvelle entre en conflit.